### PR TITLE
Syntax error, must be SSLCertificateKeyFile

### DIFF
--- a/document_root/index.html
+++ b/document_root/index.html
@@ -149,7 +149,7 @@ server {
       <p>Here's a similar configuration for Apache 2.4's <i>httpd-ssl.conf</i>:</p><pre>
 Listen 443
 SSLCertificateFile "/etc/ssl/sslip.io.chained.crt.pem"
-SLCertificateKeyFile "/etc/ssl/sslip.io.key.pem"</pre>
+SSLCertificateKeyFile "/etc/ssl/sslip.io.key.pem"</pre>
       <p class="lead">Finally, restart your webserver and browse to its sslip.io
         address via HTTPS</p>
       <p>Browse to your webserver's sslip.io hostname, e.g. <a href="https://52-0-56-137.sslip.io">https://52-0-56-137.sslip.io</a>


### PR DESCRIPTION
> AH00526: Syntax error on line 166 of httpd-ssl.conf:
> Invalid command 'SLCertificateKeyFile', perhaps misspelled or defined by a module not included in the server configuration