### PR TITLE
Fix broken links

### DIFF
--- a/docs/wildcard.md
+++ b/docs/wildcard.md
@@ -55,7 +55,7 @@ need to run your own DNS server (e.g.
 [acme-dns](https://github.com/joohoi/acme-dns), the venerable
 [BIND](https://en.wikipedia.org/wiki/BIND), the opinionated
 [djbdns](https://cr.yp.to/djbdns.html), or my personal
-[wildcard-dns-http-server](https://github.com/cunnie/sslip.io/tree/main/bosh-release/src/wildcard-dns-http-server),
+[wildcard-dns-http-server](https://github.com/cunnie/sslip.io/tree/main/src/wildcard-dns-http-server),
 etc.).  You can use any ACME client
 ([acme.sh](https://github.com/acmesh-official/acme.sh),
 [Certbot](https://certbot.eff.org/), etc.), but you must configure it to request

--- a/k8s/document_root_sslip.io/index.html
+++ b/k8s/document_root_sslip.io/index.html
@@ -152,7 +152,7 @@ src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script> <![endif]-->
       <pre><code>169.254.169.254</code></pre>
       <h3 id="server">But I Want My Own DNS Server!</h3>
       <p>If you want to run your own DNS server, it's simple: you can compile from <a href=
-      "https://github.com/cunnie/sslip.io/tree/main/bosh-release/src/sslip.io-dns-server">source</a> or you can use one
+      "https://github.com/cunnie/sslip.io/tree/main/src/sslip.io-dns-server">source</a> or you can use one
       of our <a href="https://github.com/cunnie/sslip.io/releases">pre-built binaries</a>. In the following example, we
       install & run our server within a docker container:</p>
       <pre>

--- a/src/wildcard-dns-http-server/go.mod
+++ b/src/wildcard-dns-http-server/go.mod
@@ -1,4 +1,4 @@
-module github.com/cunnie/sslip.io/bosh-release/src/wildcard-dns-http-server
+module github.com/cunnie/sslip.io/src/wildcard-dns-http-server
 
 go 1.15
 


### PR DESCRIPTION
Hello. I found a bad link on the webpage and decided to try to fix it. I also fixed two other places that had the old `bosh-release/` directory name.