### PR TITLE
Add option to explicitly delegate FQDN's

### DIFF
--- a/src/sslip.io-dns-server/xip/xip.go
+++ b/src/sslip.io-dns-server/xip/xip.go
@@ -390,8 +390,8 @@ func (x *Xip) processQuestion(q dnsmessage.Question, srcAddr net.IP) (response R
 		logMessages = append(logMessages, fmt.Sprintf("domain \"%s\" is delegated to ", q.Name.String()))
 		response.Header.Authoritative = false
 		for _, nameServer := range delegatedNameservers {
+			nameServer := nameServer
 			response.Authorities = append(response.Authorities,
-				// 1 or more A records; A records > 1 only available via Customizations
 				func(b *dnsmessage.Builder) error {
 					err = b.NSResource(dnsmessage.ResourceHeader{
 						Name:   q.Name,

--- a/src/sslip.io-dns-server/xip/xip.go
+++ b/src/sslip.io-dns-server/xip/xip.go
@@ -384,7 +384,7 @@ func (x *Xip) processQuestion(q dnsmessage.Question, srcAddr net.IP) (response R
 		},
 	}
 	// Check if domain is delegated to specified nameservers
-	delegatedNameservers, delegated := x.DelegatedFqdns[q.Name.String()]
+	delegatedNameservers, delegated := x.DelegatedFqdns[strings.ToLower(q.Name.String())]
 	if delegated {
 		var logMessages []string
 		logMessages = append(logMessages, fmt.Sprintf("domain \"%s\" is delegated to ", q.Name.String()))

--- a/src/sslip.io-dns-server/xip/xip_test.go
+++ b/src/sslip.io-dns-server/xip/xip_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Xip", func() {
 
 	Describe("NSResources()", func() {
 		When("we use the default nameservers", func() {
-			var x, _ = xip.NewXip("file:///", []string{"ns-aws.sslip.io.", "ns-azure.sslip.io.", "ns-gce.sslip.io."}, []string{})
+			var x, _ = xip.NewXip("file:///", []string{"ns-aws.sslip.io.", "ns-azure.sslip.io.", "ns-gce.sslip.io."}, []string{}, map[string][]string{})
 			It("returns the name servers", func() {
 				randomDomain := random8ByteString() + ".com."
 				ns := x.NSResources(randomDomain)
@@ -111,7 +111,7 @@ var _ = Describe("Xip", func() {
 			})
 		})
 		When("we override the default nameservers", func() {
-			var x, _ = xip.NewXip("file:///", []string{"mickey", "minn.ie.", "goo.fy"}, []string{})
+			var x, _ = xip.NewXip("file:///", []string{"mickey", "minn.ie.", "goo.fy"}, []string{}, map[string][]string{})
 			It("returns the configured servers", func() {
 				randomDomain := random8ByteString() + ".com."
 				ns := x.NSResources(randomDomain)


### PR DESCRIPTION
Following on from #24 I ended up implementing a workaround for this issue that exposes a new argument which can be used to delegate FQDN's to other nameservers. This has enabled me to successfully issue wildcard letsencrypt certificates on the sslip domain. Here's how I use it:

```
sslip.io-dns-server -delegate _acme-challenge.sslip.example.domain=ns-XXX.awsdns-XX.com.
```

Where Route53 has a hosted zone for `sslip.example.domain` and will answer authoritatively for  `_acme-challenge.sslip.example.domain`, which enables certbot to pass the acme dns-01 challenge. You could likely substitute Route53 for other nameservers using this approach although I haven't tested any others.
I'm not sure if this is something you want to bring into the mainline but thought it was worth checking.

**NOTE:** I learnt the hard way that the dns01 challenge issues mixed case queries, hence the case-insensitive match.