### PR TITLE
Blocking 6 major website mirrors

### DIFF
--- a/etc/blocklist.txt
+++ b/etc/blocklist.txt
@@ -36,3 +36,9 @@ raiffeisen # https://www.rbinternational.com/en/homepage.html
 79.137.202.34/32 # "The Global Fund"
 45.156.24.10/32 # amazon.co.jp
 91.107.154.247/32 # United Nations Population Fund UNFPA
+5.161.56.94/32 # nypost.com
+5.250.187.205/32 # brave.com
+194.116.214.162/32 # rt.com
+49.12.41.51/32 # slate.com
+104.234.196.206/32 # blizzard.com
+45.87.41.92/32 # pogo.com


### PR DESCRIPTION
The following IP addresses are mirroring major domains then using sslip.io to be indexed on search engines:

5.161.56.94/32 # nypost.com
5.250.187.205/32 # brave.com
194.116.214.162/32 # rt.com
49.12.41.51/32 # slate.com
104.234.196.206/32 # blizzard.com
45.87.41.92/32 # pogo.com